### PR TITLE
Release node-sdk

### DIFF
--- a/.changeset/tough-results-occur.md
+++ b/.changeset/tough-results-occur.md
@@ -1,0 +1,5 @@
+---
+'@chatbotkit/sdk': patch
+---
+
+Added space storage API endpoints.


### PR DESCRIPTION
Automated release from monorepo.

Pushed from `sdks/node` on branch `next` → `main`.