### PR TITLE
Release node-sdk

### DIFF
--- a/.changeset/neat-showers-wear.md
+++ b/.changeset/neat-showers-wear.md
@@ -1,0 +1,5 @@
+---
+'@chatbotkit/sdk': minor
+---
+
+Re-generated types and docs.

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @chatbotkit/agent
 
-## 1.36.0
-
-### Patch Changes
-
-- Updated dependencies [8874447]
-  - @chatbotkit/sdk@1.36.0
-
 ## 1.35.0
 
 ### Patch Changes

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatbotkit/agent",
-  "version": "1.36.0",
+  "version": "1.35.0",
   "description": "ChatBotKit Agent implementation",
   "license": "ISC",
   "engines": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @chatbotkit/cli
 
-## 1.36.0
-
-### Patch Changes
-
-- Updated dependencies [8874447]
-  - @chatbotkit/sdk@1.36.0
-  - @chatbotkit/agent@1.36.0
-
 ## 1.35.0
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatbotkit/cli",
-  "version": "1.36.0",
+  "version": "1.35.0",
   "description": "ChatBotKit command line tools",
   "license": "ISC",
   "engines": {

--- a/packages/cli/src/solution/index.js
+++ b/packages/cli/src/solution/index.js
@@ -613,8 +613,12 @@ export const TwilioIntegrationResourceConfigSchema =
       meta: z.record(z.unknown()).optional(),
       blueprintId: z.string().optional(),
       botId: z.string().optional(),
+      accountSid: z.string().optional(),
+      authToken: z.string().optional(),
+      voice: z.string().optional(),
       contactCollection: z.boolean().optional(),
       sessionDuration: z.number().optional(),
+      allowFrom: z.string().optional(),
     }),
   })
 

--- a/packages/nextauth/CHANGELOG.md
+++ b/packages/nextauth/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @chatbotkit/nextauth
 
-## 1.36.0
-
-### Patch Changes
-
-- Updated dependencies [8874447]
-  - @chatbotkit/sdk@1.36.0
-
 ## 1.35.0
 
 ### Patch Changes

--- a/packages/nextauth/package.json
+++ b/packages/nextauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatbotkit/nextauth",
-  "version": "1.36.0",
+  "version": "1.35.0",
   "description": "ChatBotKit adapter for NextAuth.js to make conversational AI bots with authentication and authorization",
   "license": "ISC",
   "engines": {

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,12 +1,5 @@
 # @chatbotkit/react
 
-## 1.36.0
-
-### Patch Changes
-
-- Updated dependencies [8874447]
-  - @chatbotkit/sdk@1.36.0
-
 ## 1.35.0
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatbotkit/react",
-  "version": "1.36.0",
+  "version": "1.35.0",
   "description": "The fastest way to build advanced AI chat bots",
   "license": "ISC",
   "engines": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @chatbotkit/sdk
 
-## 1.36.0
-
-### Minor Changes
-
-- 8874447: Re-generated types and docs.
-
 ## 1.35.0
 
 ### Minor Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatbotkit/sdk",
-  "version": "1.36.0",
+  "version": "1.35.0",
   "description": "The fastest way to build advanced AI chat bots",
   "license": "ISC",
   "engines": {

--- a/tools/create-cbk-app/CHANGELOG.md
+++ b/tools/create-cbk-app/CHANGELOG.md
@@ -1,11 +1,5 @@
 # create-cbk-app
 
-## 1.36.0
-
-### Patch Changes
-
-- @chatbotkit/cli@1.36.0
-
 ## 1.35.0
 
 ### Patch Changes

--- a/tools/create-cbk-app/package.json
+++ b/tools/create-cbk-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-cbk-app",
-  "version": "1.36.0",
+  "version": "1.35.0",
   "description": "A quick tool to create a new ChatbotKit app",
   "license": "ISC",
   "engines": {


### PR DESCRIPTION
Automated release from monorepo.

Pushed from `sdks/node` on branch `next` → `main`.