### PR TITLE
Release node-sdk

### DIFF
--- a/.changeset/gentle-islands-move.md
+++ b/.changeset/gentle-islands-move.md
@@ -1,0 +1,5 @@
+---
+'@chatbotkit/sdk': minor
+---
+
+Re-generated types.

--- a/.changeset/soft-baths-wash.md
+++ b/.changeset/soft-baths-wash.md
@@ -1,0 +1,5 @@
+---
+'@chatbotkit/sdk': patch
+---
+
+Re-generated types.

--- a/packages/agent/CHANGELOG.md
+++ b/packages/agent/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @chatbotkit/agent
 
-## 1.38.0
-
-### Patch Changes
-
-- Updated dependencies [615f992]
-- Updated dependencies [a43f9d7]
-  - @chatbotkit/sdk@1.38.0
-
 ## 1.37.1
 
 ### Patch Changes

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatbotkit/agent",
-  "version": "1.38.0",
+  "version": "1.37.1",
   "description": "ChatBotKit Agent implementation",
   "license": "ISC",
   "engines": {

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,14 +1,5 @@
 # @chatbotkit/cli
 
-## 1.38.0
-
-### Patch Changes
-
-- Updated dependencies [615f992]
-- Updated dependencies [a43f9d7]
-  - @chatbotkit/sdk@1.38.0
-  - @chatbotkit/agent@1.38.0
-
 ## 1.37.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatbotkit/cli",
-  "version": "1.38.0",
+  "version": "1.37.1",
   "description": "ChatBotKit command line tools",
   "license": "ISC",
   "engines": {

--- a/packages/cli/src/solution/index.js
+++ b/packages/cli/src/solution/index.js
@@ -290,6 +290,7 @@ export const WidgetIntegrationResourceConfigSchema =
   BasicResourceConfigSchema.extend({
     type: z.literal('widgetIntegration'),
     properties: z.object({
+      alias: z.string().optional(),
       name: z.string().optional(),
       description: z.string().optional(),
       meta: z.record(z.unknown()).optional(),
@@ -335,6 +336,7 @@ export const SitemapIntegrationResourceConfigSchema =
   BasicResourceConfigSchema.extend({
     type: z.literal('sitemapIntegration'),
     properties: z.object({
+      alias: z.string().optional(),
       name: z.string().optional(),
       description: z.string().optional(),
       meta: z.record(z.unknown()).optional(),
@@ -358,6 +360,7 @@ export const SlackIntegrationResourceConfigSchema =
   BasicResourceConfigSchema.extend({
     type: z.literal('slackIntegration'),
     properties: z.object({
+      alias: z.string().optional(),
       name: z.string().optional(),
       description: z.string().optional(),
       meta: z.record(z.unknown()).optional(),
@@ -386,6 +389,7 @@ export const DiscordIntegrationResourceConfigSchema =
   BasicResourceConfigSchema.extend({
     type: z.literal('discordIntegration'),
     properties: z.object({
+      alias: z.string().optional(),
       name: z.string().optional(),
       description: z.string().optional(),
       meta: z.record(z.unknown()).optional(),
@@ -413,6 +417,7 @@ export const TelegramIntegrationResourceConfigSchema =
   BasicResourceConfigSchema.extend({
     type: z.literal('telegramIntegration'),
     properties: z.object({
+      alias: z.string().optional(),
       name: z.string().optional(),
       description: z.string().optional(),
       meta: z.record(z.unknown()).optional(),
@@ -435,6 +440,7 @@ export const WhatsAppIntegrationResourceConfigSchema =
   BasicResourceConfigSchema.extend({
     type: z.literal('whatsappIntegration'),
     properties: z.object({
+      alias: z.string().optional(),
       name: z.string().optional(),
       description: z.string().optional(),
       meta: z.record(z.unknown()).optional(),
@@ -458,6 +464,7 @@ export const MessengerIntegrationResourceConfigSchema =
   BasicResourceConfigSchema.extend({
     type: z.literal('messengerIntegration'),
     properties: z.object({
+      alias: z.string().optional(),
       name: z.string().optional(),
       description: z.string().optional(),
       meta: z.record(z.unknown()).optional(),
@@ -479,6 +486,7 @@ export const NotionIntegrationResourceConfigSchema =
   BasicResourceConfigSchema.extend({
     type: z.literal('notionIntegration'),
     properties: z.object({
+      alias: z.string().optional(),
       name: z.string().optional(),
       description: z.string().optional(),
       meta: z.record(z.unknown()).optional(),
@@ -499,6 +507,7 @@ export const EmailIntegrationResourceConfigSchema =
   BasicResourceConfigSchema.extend({
     type: z.literal('emailIntegration'),
     properties: z.object({
+      alias: z.string().optional(),
       name: z.string().optional(),
       description: z.string().optional(),
       meta: z.record(z.unknown()).optional(),
@@ -520,6 +529,7 @@ export const TriggerIntegrationResourceConfigSchema =
   BasicResourceConfigSchema.extend({
     type: z.literal('triggerIntegration'),
     properties: z.object({
+      alias: z.string().optional(),
       name: z.string().optional(),
       description: z.string().optional(),
       meta: z.record(z.unknown()).optional(),
@@ -551,6 +561,7 @@ export const SupportIntegrationResourceConfigSchema =
   BasicResourceConfigSchema.extend({
     type: z.literal('supportIntegration'),
     properties: z.object({
+      alias: z.string().optional(),
       name: z.string().optional(),
       description: z.string().optional(),
       meta: z.record(z.unknown()).optional(),
@@ -570,6 +581,7 @@ export const ExtractIntegrationResourceConfigSchema =
   BasicResourceConfigSchema.extend({
     type: z.literal('extractIntegration'),
     properties: z.object({
+      alias: z.string().optional(),
       name: z.string().optional(),
       description: z.string().optional(),
       meta: z.record(z.unknown()).optional(),
@@ -590,6 +602,7 @@ export const McpServerIntegrationResourceConfigSchema =
   BasicResourceConfigSchema.extend({
     type: z.literal('mcpserverIntegration'),
     properties: z.object({
+      alias: z.string().optional(),
       name: z.string().optional(),
       description: z.string().optional(),
       meta: z.record(z.unknown()).optional(),
@@ -608,6 +621,7 @@ export const TwilioIntegrationResourceConfigSchema =
   BasicResourceConfigSchema.extend({
     type: z.literal('twilioIntegration'),
     properties: z.object({
+      alias: z.string().optional(),
       name: z.string().optional(),
       description: z.string().optional(),
       meta: z.record(z.unknown()).optional(),

--- a/packages/nextauth/CHANGELOG.md
+++ b/packages/nextauth/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @chatbotkit/nextauth
 
-## 1.38.0
-
-### Patch Changes
-
-- Updated dependencies [615f992]
-- Updated dependencies [a43f9d7]
-  - @chatbotkit/sdk@1.38.0
-
 ## 1.37.1
 
 ### Patch Changes

--- a/packages/nextauth/package.json
+++ b/packages/nextauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatbotkit/nextauth",
-  "version": "1.38.0",
+  "version": "1.37.1",
   "description": "ChatBotKit adapter for NextAuth.js to make conversational AI bots with authentication and authorization",
   "license": "ISC",
   "engines": {

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @chatbotkit/react
 
-## 1.38.0
-
-### Patch Changes
-
-- Updated dependencies [615f992]
-- Updated dependencies [a43f9d7]
-  - @chatbotkit/sdk@1.38.0
-
 ## 1.37.1
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatbotkit/react",
-  "version": "1.38.0",
+  "version": "1.37.1",
   "description": "The fastest way to build advanced AI chat bots",
   "license": "ISC",
   "engines": {

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,15 +1,5 @@
 # @chatbotkit/sdk
 
-## 1.38.0
-
-### Minor Changes
-
-- 615f992: Re-generated types.
-
-### Patch Changes
-
-- a43f9d7: Re-generated types.
-
 ## 1.37.1
 
 ### Patch Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chatbotkit/sdk",
-  "version": "1.38.0",
+  "version": "1.37.1",
   "description": "The fastest way to build advanced AI chat bots",
   "license": "ISC",
   "engines": {

--- a/tools/create-cbk-app/CHANGELOG.md
+++ b/tools/create-cbk-app/CHANGELOG.md
@@ -1,11 +1,5 @@
 # create-cbk-app
 
-## 1.38.0
-
-### Patch Changes
-
-- @chatbotkit/cli@1.38.0
-
 ## 1.37.1
 
 ### Patch Changes

--- a/tools/create-cbk-app/package.json
+++ b/tools/create-cbk-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-cbk-app",
-  "version": "1.38.0",
+  "version": "1.37.1",
   "description": "A quick tool to create a new ChatbotKit app",
   "license": "ISC",
   "engines": {


### PR DESCRIPTION
Automated release from monorepo.

Pushed from `sdks/node` on branch `next` → `main`.