### PR TITLE
Fix SDK types for the current platform API

### DIFF
--- a/.changeset/linked-ability-fields.md
+++ b/.changeset/linked-ability-fields.md
@@ -1,0 +1,7 @@
+---
+"@chatbotkit/sdk": minor
+---
+
+BREAKING: skillset ability link fields renamed. On create/update/fetch/list/export, `secretId` / `fileId` / `botId` / `spaceId` are now `linkedSecretId` / `linkedFileId` / `linkedBotId` / `linkedSpaceId`. Inline conversation `extensions.skillsets[].abilities[]` entries use `linkedSecretId` (and the new `linkedSpaceId`). GraphQL `Ability` relations `secret` / `file` / `bot` / `space` are now `linkedSecret` / `linkedFile` / `linkedBot` / `linkedSpace`. There are no compatibility aliases; upgrade together with the platform deploy.
+
+Also in this release, from the regenerated `src/types/ability.d.ts`: the `'browser/dispatch'` ability name and the `BrowserDispatchParameters` export are gone (the ability was removed from the platform catalogue), and `BlueprintBulletinCreateParameters.ttl` is now `string` (seconds or a duration such as `"1 hour"`) instead of `number`. Both are breaking for code typed against those exports.

--- a/.changeset/platform-api-contract.md
+++ b/.changeset/platform-api-contract.md
@@ -1,0 +1,6 @@
+---
+'@chatbotkit/sdk': minor
+---
+
+Refresh the generated platform API contract so SDK request and response types
+match the current GraphQL, task, integration, dataset, and space APIs.

--- a/.changeset/space-site-slug.md
+++ b/.changeset/space-site-slug.md
@@ -1,0 +1,5 @@
+---
+'@chatbotkit/sdk': minor
+---
+
+BREAKING: SpaceSite API request and response fields now use `slug` instead of `domain`. Create requests require `slug`; update requests accept an optional `slug`; fetch and list responses expose `slug`.

--- a/packages/sdk/src/types/ability.d.ts
+++ b/packages/sdk/src/types/ability.d.ts
@@ -31,7 +31,6 @@ export type CbkAbilityName = 'abort'
   | 'bot/call[by-id]'
   | 'bot/call[multi]'
   | 'bot/list'
-  | 'browser/dispatch'
   | 'conversation/fetch[bot][by-id]'
   | 'conversation/fetch[by-id]'
   | 'conversation/fetch[contact][by-id]'
@@ -74,17 +73,20 @@ export type CbkAbilityName = 'abort'
   | 'file/write'
   | 'file/write[by-id]'
   | 'git/file/fetch'
+  | 'git/skill/list'
   | 'git/tree/fetch'
   | 'graphql[cbk]'
   | 'image/generate'
   | 'image/generate[gemini-2.5-flash-image]'
   | 'image/generate[gemini-3.1-flash-image]'
+  | 'image/generate[gemini-3.1-flash-lite-image]'
   | 'image/generate[gpt-image-1.5]'
   | 'image/generate[gpt-image-1]'
   | 'image/generate[gpt-image-2]'
   | 'image/modify'
   | 'image/modify[gemini-2.5-flash-image]'
   | 'image/modify[gemini-3.1-flash-image]'
+  | 'image/modify[gemini-3.1-flash-lite-image]'
   | 'image/modify[gpt-image-1.5]'
   | 'image/modify[gpt-image-1]'
   | 'image/modify[gpt-image-2]'
@@ -116,12 +118,16 @@ export type CbkAbilityName = 'abort'
   | 'mock/dataset'
   | 'mock/sql'
   | 'pack/bot/reprogramming'
+  | 'pack/cbk/git/repo'
+  | 'pack/cbk/git/skills'
+  | 'pack/cbk/research'
   | 'pack/cbk/space/skills'
   | 'pack/cbk/space/skills[authoring]'
   | 'pack/cbk/space/storage'
   | 'pack/cbk/space/storage[read-only]'
   | 'pack/file'
   | 'pack/file[by-id]'
+  | 'pack/memory'
   | 'pack/rating'
   | 'pack/rating[by-bot-id]'
   | 'pack/rating[contact]'
@@ -172,8 +178,12 @@ export type CbkAbilityName = 'abort'
   | 'space/list[contact]'
   | 'space/skill/create'
   | 'space/skill/create[by-id]'
+  | 'space/skill/delete'
+  | 'space/skill/delete[by-id]'
   | 'space/skill/list'
   | 'space/skill/list[by-id]'
+  | 'space/skill/move'
+  | 'space/skill/move[by-id]'
   | 'space/skill/read'
   | 'space/skill/read[by-id]'
   | 'space/storage/copy'
@@ -307,8 +317,8 @@ export type AvatarUrlIntegrationByIdParameters = {
 export type BlueprintBulletinCreateParameters = {
  /** the message to post to the shared bulletin board */
   text: string
- /** optional time-to-live in seconds before the bulletin expires */
-  ttl?: number
+ /** optional time-to-live before the bulletin expires - a number of seconds or a duration like "1 hour", "30 minutes" or "2d" */
+  ttl?: string
 }
 
 export type BlueprintBulletinListParameters = Record<string, never>
@@ -411,15 +421,6 @@ export type BotCallMultiParameters = {
 export type BotListParameters = {
  /** optional limit on the number of bots to return */
   take?: number
-}
-
-export type BrowserDispatchParameters = {
- /** the task to perform in the browser */
-  task: string
- /** optional URL of the page to dispatch the action */
-  url?: string
- /** timeout in milliseconds */
-  timeout?: number
 }
 
 export type ConversationFetchBotByIdParameters = {
@@ -692,6 +693,15 @@ export type GitFileFetchParameters = {
   filePath: string
 }
 
+export type GitSkillListParameters = {
+ /** Git repository URL */
+  url: string
+ /** Git reference (branch, tag, or commit SHA) */
+  ref: string
+ /** Directory to scan for skills (holding skill folders each with a SKILL.md). Defaults to "skills" when omitted. Use ".claude/skills" or ".github/skills" for internal repos. */
+  directory: string
+}
+
 export type GitTreeFetchParameters = {
  /** Git repository URL */
   url: string
@@ -725,6 +735,13 @@ export type ImageGenerateGemini25FlashImageParameters = {
 }
 
 export type ImageGenerateGemini31FlashImageParameters = {
+ /** the prompt to use for image generation */
+  prompt: string
+ /** detailed directions how to generate the image */
+  directions?: string
+}
+
+export type ImageGenerateGemini31FlashLiteImageParameters = {
  /** the prompt to use for image generation */
   prompt: string
  /** detailed directions how to generate the image */
@@ -771,6 +788,15 @@ export type ImageModifyGemini25FlashImageParameters = {
 }
 
 export type ImageModifyGemini31FlashImageParameters = {
+ /** the prompt to use for image generation */
+  prompt: string
+ /** detailed directions how to modify the image */
+  directions?: string
+ /** the URL of the image to edit */
+  image_url: string
+}
+
+export type ImageModifyGemini31FlashLiteImageParameters = {
  /** the prompt to use for image generation */
   prompt: string
  /** detailed directions how to modify the image */
@@ -953,6 +979,12 @@ export type MockSqlParameters = {
 
 export type PackBotReprogrammingParameters = Record<string, never>
 
+export type PackCbkGitRepoParameters = Record<string, never>
+
+export type PackCbkGitSkillsParameters = Record<string, never>
+
+export type PackCbkResearchParameters = Record<string, never>
+
 export type PackCbkSpaceSkillsParameters = Record<string, never>
 
 export type PackCbkSpaceSkillsAuthoringParameters = Record<string, never>
@@ -964,6 +996,8 @@ export type PackCbkSpaceStorageReadOnlyParameters = Record<string, never>
 export type PackFileParameters = Record<string, never>
 
 export type PackFileByIdParameters = Record<string, never>
+
+export type PackMemoryParameters = Record<string, never>
 
 export type PackRatingParameters = Record<string, never>
 
@@ -1292,11 +1326,39 @@ export type SpaceSkillCreateByIdParameters = {
   content: string
 }
 
+export type SpaceSkillDeleteParameters = {
+ /** The kebab-case slug of the skill to delete, matching its directory name under .skills/ */
+  slug: string
+}
+
+export type SpaceSkillDeleteByIdParameters = {
+ /** The ID of the space to delete the skill(s) from */
+  spaceId: string
+ /** The kebab-case slug of the skill to delete, matching its directory name under .skills/ */
+  slug: string
+}
+
 export type SpaceSkillListParameters = Record<string, never>
 
 export type SpaceSkillListByIdParameters = {
  /** The ID of the space to list skills from */
   spaceId: string
+}
+
+export type SpaceSkillMoveParameters = {
+ /** The current kebab-case slug of the skill to rename, matching its directory name under .skills/ */
+  from: string
+ /** The new kebab-case slug for the skill */
+  to: string
+}
+
+export type SpaceSkillMoveByIdParameters = {
+ /** The ID of the space to rename the skill(s) in */
+  spaceId: string
+ /** The current kebab-case slug of the skill to rename, matching its directory name under .skills/ */
+  from: string
+ /** The new kebab-case slug for the skill */
+  to: string
 }
 
 export type SpaceSkillReadParameters = {
@@ -1506,7 +1568,7 @@ export type TaskCreateParameters = {
   name: string
  /** a detailed description that captures all the necessary information to complete the task */
   description: string
- /** optional schedule - now, 2027-12-31T23:59:59, quarterhourly, halfhourly, hourly, daily, weekly, monthly, 0 0 * * * */
+ /** optional schedule - now, 2027-12-31T23:59:59, quarterhourly, halfhourly, hourly, daily, weekly, monthly, or cron 0 0 * * * */
   schedule?: string
  /** optional max reasoning iterations per run (clamped 10–100000; default 1000) */
   maxIterations?: number
@@ -1523,7 +1585,7 @@ export type TaskCreateByBotIdParameters = {
   name: string
  /** a detailed description that captures all the necessary information to complete the task */
   description: string
- /** optional schedule - now, 2027-12-31T23:59:59, quarterhourly, halfhourly, hourly, daily, weekly, monthly, 0 0 * * * */
+ /** optional schedule - now, 2027-12-31T23:59:59, quarterhourly, halfhourly, hourly, daily, weekly, monthly, or cron 0 0 * * * */
   schedule?: string
  /** optional max reasoning iterations per run (clamped 10–100000; default 1000) */
   maxIterations?: number
@@ -1538,7 +1600,7 @@ export type TaskCreateContactParameters = {
   name: string
  /** a detailed description that captures all the necessary information to complete the task */
   description: string
- /** optional schedule - now, 2027-12-31T23:59:59, quarterhourly, halfhourly, hourly, daily, weekly, monthly, 0 0 * * * */
+ /** optional schedule - now, 2027-12-31T23:59:59, quarterhourly, halfhourly, hourly, daily, weekly, monthly, or cron 0 0 * * * */
   schedule?: string
  /** optional max reasoning iterations per run (clamped 10–100000; default 1000) */
   maxIterations?: number
@@ -1555,7 +1617,7 @@ export type TaskCreateContactByBotIdParameters = {
   name: string
  /** a detailed description that captures all the necessary information to complete the task */
   description: string
- /** optional schedule - now, 2027-12-31T23:59:59, quarterhourly, halfhourly, hourly, daily, weekly, monthly, 0 0 * * * */
+ /** optional schedule - now, 2027-12-31T23:59:59, quarterhourly, halfhourly, hourly, daily, weekly, monthly, or cron 0 0 * * * */
   schedule?: string
  /** optional max reasoning iterations per run (clamped 10–100000; default 1000) */
   maxIterations?: number
@@ -1658,7 +1720,7 @@ export type TaskUpdateParameters = {
   name: string
  /** an updated detailed description that captures all the necessary information to complete the task */
   description: string
- /** optional schedule - now, 2027-12-31T23:59:59, quarterhourly, halfhourly, hourly, daily, weekly, monthly, 0 0 * * * */
+ /** optional schedule - now, 2027-12-31T23:59:59, quarterhourly, halfhourly, hourly, daily, weekly, monthly, or cron 0 0 * * * */
   schedule?: string
  /** optional max reasoning iterations per run (clamped 10–100000; default 1000) */
   maxIterations?: number
@@ -1677,7 +1739,7 @@ export type TaskUpdateByBotIdParameters = {
   name: string
  /** an updated detailed description that captures all the necessary information to complete the task */
   description: string
- /** optional schedule - now, 2027-12-31T23:59:59, quarterhourly, halfhourly, hourly, daily, weekly, monthly, 0 0 * * * */
+ /** optional schedule - now, 2027-12-31T23:59:59, quarterhourly, halfhourly, hourly, daily, weekly, monthly, or cron 0 0 * * * */
   schedule?: string
  /** optional max reasoning iterations per run (clamped 10–100000; default 1000) */
   maxIterations?: number
@@ -1694,7 +1756,7 @@ export type TaskUpdateContactParameters = {
   name: string
  /** an updated detailed description that captures all the necessary information to complete the task */
   description: string
- /** optional schedule - now, 2027-12-31T23:59:59, quarterhourly, halfhourly, hourly, daily, weekly, monthly, 0 0 * * * */
+ /** optional schedule - now, 2027-12-31T23:59:59, quarterhourly, halfhourly, hourly, daily, weekly, monthly, or cron 0 0 * * * */
   schedule?: string
  /** optional max reasoning iterations per run (clamped 10–100000; default 1000) */
   maxIterations?: number
@@ -1713,7 +1775,7 @@ export type TaskUpdateContactByBotIdParameters = {
   name: string
  /** an updated detailed description that captures all the necessary information to complete the task */
   description: string
- /** optional schedule - now, 2027-12-31T23:59:59, quarterhourly, halfhourly, hourly, daily, weekly, monthly, 0 0 * * * */
+ /** optional schedule - now, 2027-12-31T23:59:59, quarterhourly, halfhourly, hourly, daily, weekly, monthly, or cron 0 0 * * * */
   schedule?: string
  /** optional max reasoning iterations per run (clamped 10–100000; default 1000) */
   maxIterations?: number
@@ -1866,7 +1928,7 @@ export interface CbkAbilityRegistry {
   }
   'attachment/read': {
     name: 'Read Attachment'
-    description: 'Read and extract content from uploaded file attachments. For text-based files, extracts and returns the text content. For image files (png, jpg, jpeg, gif, webp, bmp, tiff, svg), analyzes the image using vision capabilities. Locate the corresponding tool call for the attachment information. Does not support audio or video files.'
+    description: 'Read and extract content from uploaded file attachments. For text-based files, extracts and returns the text content. For image files (png, jpg, jpeg, gif, webp, bmp, tiff, svg), analyzes the image using vision capabilities. For audio files (mp3, m4a, wav, ogg, oga, opus, flac, aac), including voice notes, transcribes the audio to text. Locate the corresponding tool call for the attachment information. Does not support video files.'
     parameters: AttachmentReadParameters
   }
   'avatar/url[integration-by-id]': {
@@ -1963,11 +2025,6 @@ export interface CbkAbilityRegistry {
     name: 'List Bots'
     description: 'List all available bots for the current user account'
     parameters: BotListParameters
-  }
-  'browser/dispatch': {
-    name: 'Dispatch Browser Task'
-    description: 'Dispatch a specific task within a live web browser.'
-    parameters: BrowserDispatchParameters
   }
   'conversation/fetch[bot][by-id]': {
     name: 'Fetch Conversation'
@@ -2179,6 +2236,11 @@ export interface CbkAbilityRegistry {
     description: 'Fetches a file from a Git repository at a specific reference.'
     parameters: GitFileFetchParameters
   }
+  'git/skill/list': {
+    name: 'List Git Skills'
+    description: 'Lists all skills in a Git repository by scanning its .skills, .github/skills, and .claude/skills directories at a specific reference. Returns the name, description, and path for each skill found.'
+    parameters: GitSkillListParameters
+  }
   'git/tree/fetch': {
     name: 'Fetch Git Tree'
     description: 'Fetches all files from a directory in a Git repository at a specific reference.'
@@ -2203,6 +2265,11 @@ export interface CbkAbilityRegistry {
     name: 'Generate Image'
     description: 'Generate an image using the Gemini 3.1 Flash Image model with Pro-level visual quality at Flash speed.'
     parameters: ImageGenerateGemini31FlashImageParameters
+  }
+  'image/generate[gemini-3.1-flash-lite-image]': {
+    name: 'Generate Image'
+    description: 'Generate an image using the Gemini 3.1 Flash Lite Image model, a fast, lower-cost option optimized for high-volume visual workflows.'
+    parameters: ImageGenerateGemini31FlashLiteImageParameters
   }
   'image/generate[gpt-image-1.5]': {
     name: 'Generate Image'
@@ -2233,6 +2300,11 @@ export interface CbkAbilityRegistry {
     name: 'Modify Image'
     description: 'Create a new image from previous input images using the Gemini 3.1 Flash Image model.'
     parameters: ImageModifyGemini31FlashImageParameters
+  }
+  'image/modify[gemini-3.1-flash-lite-image]': {
+    name: 'Modify Image'
+    description: 'Create a new image from previous input images using the Gemini 3.1 Flash Lite Image model.'
+    parameters: ImageModifyGemini31FlashLiteImageParameters
   }
   'image/modify[gpt-image-1.5]': {
     name: 'Modify Image'
@@ -2389,6 +2461,21 @@ export interface CbkAbilityRegistry {
     description: 'Installs bot backstory read and write tools into the conversation. You can read the current backstory of the connected bot and overwrite it with new content.'
     parameters: PackBotReprogrammingParameters
   }
+  'pack/cbk/git/repo': {
+    name: 'Install Git Repository Tools'
+    description: 'Installs Git repository reading tools into the conversation. Fetch an individual file or a whole directory tree from any public Git repository at a given ref, no space required.'
+    parameters: PackCbkGitRepoParameters
+  }
+  'pack/cbk/git/skills': {
+    name: 'Install Git Skills Tools'
+    description: 'Installs Git skills tools into the conversation. You can list available skills in a Git repository and fetch their files directly from the repo, no space required.'
+    parameters: PackCbkGitSkillsParameters
+  }
+  'pack/cbk/research': {
+    name: 'Install Research Tools'
+    description: 'Installs web research tools into the conversation. You can search the web, search recent news, and fetch the content of a web page as text.'
+    parameters: PackCbkResearchParameters
+  }
   'pack/cbk/space/skills': {
     name: 'Install Space Skills Tools'
     description: 'Installs space skills tools into the conversation. You can list available skills and read their full content from the linked space.'
@@ -2396,7 +2483,7 @@ export interface CbkAbilityRegistry {
   }
   'pack/cbk/space/skills[authoring]': {
     name: 'Install Space Skills Authoring Tools'
-    description: 'Installs space skills authoring tools into the conversation. You can list available skills, read their full content, and create new skills in the linked space.'
+    description: 'Installs space skills authoring tools into the conversation. You can list available skills, read their full content, create new skills, rename them, and delete them in the linked space.'
     parameters: PackCbkSpaceSkillsAuthoringParameters
   }
   'pack/cbk/space/storage': {
@@ -2418,6 +2505,11 @@ export interface CbkAbilityRegistry {
     name: 'Install File Tools'
     description: 'Installs file tools into the conversation to read, write, prepend, append, and replace content in files by specifying the file ID.'
     parameters: PackFileByIdParameters
+  }
+  'pack/memory': {
+    name: 'Install Memory Tools'
+    description: 'Installs memory tools into the conversation. You can search, list, create, update, and delete durable memories within the account.'
+    parameters: PackMemoryParameters
   }
   'pack/rating': {
     name: 'Install Rating Tools'
@@ -2669,6 +2761,16 @@ export interface CbkAbilityRegistry {
     description: 'Creates one or more skills in the specified space under the .skills directory. Each skill is stored as a SKILL.md file with frontmatter containing the name and description.'
     parameters: SpaceSkillCreateByIdParameters
   }
+  'space/skill/delete': {
+    name: 'Delete Space Skills'
+    description: 'Deletes one or more skills from the linked space by their slug. Removes the entire skill directory under .skills/, including the SKILL.md and any supporting files.'
+    parameters: SpaceSkillDeleteParameters
+  }
+  'space/skill/delete[by-id]': {
+    name: 'Delete Space Skills'
+    description: 'Deletes one or more skills from the specified space by their slug. Removes the entire skill directory under .skills/, including the SKILL.md and any supporting files.'
+    parameters: SpaceSkillDeleteByIdParameters
+  }
   'space/skill/list': {
     name: 'List Space Skills'
     description: 'Lists all available skills in the linked space by scanning .skills, .github/skills, and .claude/skills directories. Returns the name, description, and path for each skill found.'
@@ -2678,6 +2780,16 @@ export interface CbkAbilityRegistry {
     name: 'List Space Skills'
     description: 'Lists all available skills in the space by scanning .skills, .github/skills, and .claude/skills directories. Returns the name, description, and path for each skill found.'
     parameters: SpaceSkillListByIdParameters
+  }
+  'space/skill/move': {
+    name: 'Move Space Skills'
+    description: 'Renames one or more skills in the linked space by changing their slug. Moves the entire skill directory under .skills/ from the old slug to the new one, including the SKILL.md and any supporting files.'
+    parameters: SpaceSkillMoveParameters
+  }
+  'space/skill/move[by-id]': {
+    name: 'Move Space Skills'
+    description: 'Renames one or more skills in the specified space by changing their slug. Moves the entire skill directory under .skills/ from the old slug to the new one, including the SKILL.md and any supporting files.'
+    parameters: SpaceSkillMoveByIdParameters
   }
   'space/skill/read': {
     name: 'Read Space Skills'

--- a/packages/sdk/src/types/api/v1.d.ts
+++ b/packages/sdk/src/types/api/v1.d.ts
@@ -13645,7 +13645,7 @@ export interface operations {
             content: {
                 "application/json": {
                     /** @description The unique alias for the instance */
-                    alias?: string;
+                    alias?: string | null;
                     /** @description The associated name */
                     name?: string;
                     /** @description The associated description */
@@ -13655,7 +13655,7 @@ export interface operations {
                         [key: string]: unknown;
                     };
                     /** @description The ID of the blueprint */
-                    blueprintId?: string;
+                    blueprintId?: string | null;
                     /** @description The reranker class for the dataset */
                     reranker?: string;
                     /** @description The total number of tokens to for each record */
@@ -13713,7 +13713,7 @@ export interface operations {
             content: {
                 "application/json": {
                     /** @description The unique alias for the instance */
-                    alias?: string;
+                    alias?: string | null;
                     /** @description The associated name */
                     name?: string;
                     /** @description The associated description */
@@ -13723,9 +13723,7 @@ export interface operations {
                         [key: string]: unknown;
                     };
                     /** @description The ID of the blueprint */
-                    blueprintId?: string;
-                    /** @description The storage class for the dataset */
-                    store?: string;
+                    blueprintId?: string | null;
                     /** @description The reranker class for the dataset */
                     reranker?: string;
                     /** @description The total number of tokens for each record */
@@ -16561,7 +16559,7 @@ export interface operations {
             content: {
                 "application/json": {
                     /** @description The unique alias for the instance */
-                    alias?: string;
+                    alias?: string | null;
                     /** @description The associated name */
                     name?: string;
                     /** @description The associated description */
@@ -16571,15 +16569,17 @@ export interface operations {
                         [key: string]: unknown;
                     };
                     /** @description The ID of the blueprint */
-                    blueprintId?: string;
+                    blueprintId?: string | null;
                     /** @description The ID of the bot this configuration is using */
-                    botId?: string;
+                    botId?: string | null;
                     /** @description The Instagram integration access token */
-                    accessToken?: string;
+                    accessToken?: string | null;
+                    /** @description The Meta app secret used to validate webhook signatures */
+                    appSecret?: string | null;
                     /** @description Whether to collect contacts */
                     contactCollection?: boolean;
                     /** @description The session duration (in milliseconds) */
-                    sessionDuration?: number;
+                    sessionDuration?: number | null;
                     /** @description Whether the bot supports attachments */
                     attachments?: boolean;
                 };
@@ -16618,7 +16618,7 @@ export interface operations {
             content: {
                 "application/json": {
                     /** @description The unique alias for the instance */
-                    alias?: string;
+                    alias?: string | null;
                     /** @description The associated name */
                     name?: string;
                     /** @description The associated description */
@@ -16628,15 +16628,17 @@ export interface operations {
                         [key: string]: unknown;
                     };
                     /** @description The ID of the blueprint */
-                    blueprintId?: string;
+                    blueprintId?: string | null;
                     /** @description The ID of the bot this configuration is using */
-                    botId?: string;
+                    botId?: string | null;
                     /** @description The Instagram integration access token */
-                    accessToken?: string;
+                    accessToken?: string | null;
+                    /** @description The Meta app secret used to validate webhook signatures */
+                    appSecret?: string | null;
                     /** @description Whether to collect contacts */
                     contactCollection?: boolean;
                     /** @description The session duration (in milliseconds) */
-                    sessionDuration?: number;
+                    sessionDuration?: number | null;
                     /** @description Whether the bot supports attachments */
                     attachments?: boolean;
                 };
@@ -17203,7 +17205,7 @@ export interface operations {
             content: {
                 "application/json": {
                     /** @description The unique alias for the instance */
-                    alias?: string;
+                    alias?: string | null;
                     /** @description The associated name */
                     name?: string;
                     /** @description The associated description */
@@ -17213,15 +17215,17 @@ export interface operations {
                         [key: string]: unknown;
                     };
                     /** @description The ID of the blueprint */
-                    blueprintId?: string;
+                    blueprintId?: string | null;
                     /** @description The ID of the bot this configuration is using */
-                    botId?: string;
+                    botId?: string | null;
                     /** @description The Messenger integration access token */
-                    accessToken?: string;
+                    accessToken?: string | null;
+                    /** @description The Meta app secret used to validate webhook signatures */
+                    appSecret?: string | null;
                     /** @description Whether to collect contacts */
                     contactCollection?: boolean;
                     /** @description The session duration (in milliseconds) */
-                    sessionDuration?: number;
+                    sessionDuration?: number | null;
                     /** @description Whether the bot supports attachments */
                     attachments?: boolean;
                 };
@@ -17260,7 +17264,7 @@ export interface operations {
             content: {
                 "application/json": {
                     /** @description The unique alias for the instance */
-                    alias?: string;
+                    alias?: string | null;
                     /** @description The associated name */
                     name?: string;
                     /** @description The associated description */
@@ -17270,15 +17274,17 @@ export interface operations {
                         [key: string]: unknown;
                     };
                     /** @description The ID of the blueprint */
-                    blueprintId?: string;
+                    blueprintId?: string | null;
                     /** @description The ID of the bot this configuration is using */
-                    botId?: string;
+                    botId?: string | null;
                     /** @description The Messenger integration access token */
-                    accessToken?: string;
+                    accessToken?: string | null;
+                    /** @description The Meta app secret used to validate webhook signatures */
+                    appSecret?: string | null;
                     /** @description Whether to collect contacts */
                     contactCollection?: boolean;
                     /** @description The session duration (in milliseconds) */
-                    sessionDuration?: number;
+                    sessionDuration?: number | null;
                     /** @description Whether the bot supports attachments */
                     attachments?: boolean;
                 };
@@ -20914,7 +20920,7 @@ export interface operations {
             content: {
                 "application/json": {
                     /** @description The unique alias for the instance */
-                    alias?: string;
+                    alias?: string | null;
                     /** @description The associated name */
                     name?: string;
                     /** @description The associated description */
@@ -20924,21 +20930,23 @@ export interface operations {
                         [key: string]: unknown;
                     };
                     /** @description The ID of the blueprint */
-                    blueprintId?: string;
+                    blueprintId?: string | null;
                     /** @description The ID of the bot this configuration is using */
-                    botId?: string;
+                    botId?: string | null;
                     /** @description The WhatsApp integration phone number ID */
-                    phoneNumberId?: string;
+                    phoneNumberId?: string | null;
                     /** @description The WhatsApp integration access token */
-                    accessToken?: string;
+                    accessToken?: string | null;
+                    /** @description The Meta app secret used to validate webhook signatures */
+                    appSecret?: string | null;
                     /** @description Weather to collect contacts */
                     contactCollection?: boolean;
                     /** @description The session duration (in milliseconds) */
-                    sessionDuration?: number;
+                    sessionDuration?: number | null;
                     /** @description Weather the bot supports attachments */
                     attachments?: boolean;
                     /** @description Newline-or-comma-separated list of allowed senders. Use E.164 phone numbers with or without the leading `+`. Set to `*` to allow all. Leave empty to deny all. */
-                    allowFrom?: string;
+                    allowFrom?: string | null;
                 };
             };
         };
@@ -20975,7 +20983,7 @@ export interface operations {
             content: {
                 "application/json": {
                     /** @description The unique alias for the instance */
-                    alias?: string;
+                    alias?: string | null;
                     /** @description The associated name */
                     name?: string;
                     /** @description The associated description */
@@ -20985,21 +20993,23 @@ export interface operations {
                         [key: string]: unknown;
                     };
                     /** @description The ID of the blueprint */
-                    blueprintId?: string;
+                    blueprintId?: string | null;
                     /** @description The ID of the bot this configuration is using */
-                    botId?: string;
+                    botId?: string | null;
                     /** @description The WhatsApp integration phone number ID */
-                    phoneNumberId?: string;
+                    phoneNumberId?: string | null;
                     /** @description The WhatsApp integration access token */
-                    accessToken?: string;
+                    accessToken?: string | null;
+                    /** @description The Meta app secret used to validate webhook signatures */
+                    appSecret?: string | null;
                     /** @description Weather to collect contacts */
                     contactCollection?: boolean;
                     /** @description The session duration (in milliseconds) */
-                    sessionDuration?: number;
+                    sessionDuration?: number | null;
                     /** @description Weather the bot supports attachments */
                     attachments?: boolean;
                     /** @description Newline-or-comma-separated list of allowed senders. Use E.164 phone numbers with or without the leading `+`. Set to `*` to allow all. Leave empty to deny all. */
-                    allowFrom?: string;
+                    allowFrom?: string | null;
                 };
             };
         };
@@ -25207,7 +25217,7 @@ export interface operations {
             content: {
                 "application/json": {
                     /** @description The unique alias for the instance */
-                    alias?: string;
+                    alias?: string | null;
                     /** @description The associated name */
                     name?: string;
                     /** @description The associated description */
@@ -25217,7 +25227,7 @@ export interface operations {
                         [key: string]: unknown;
                     };
                     /** @description The ID of the blueprint */
-                    blueprintId?: string;
+                    blueprintId?: string | null;
                     /** @description The ID of the bot this policy applies to. When omitted the policy is global and applies to every bot. */
                     botId?: string;
                     /**
@@ -25225,6 +25235,11 @@ export interface operations {
                      * @enum {string}
                      */
                     type?: "retention" | "usage";
+                    /**
+                     * @description The lifecycle state of a resource - toggle it on/off without deleting it
+                     * @enum {string}
+                     */
+                    state?: "enabled" | "disabled";
                     /** @description The policy configuration as JSON */
                     config?: {
                         [key: string]: unknown;
@@ -25265,7 +25280,7 @@ export interface operations {
             content: {
                 "application/json": {
                     /** @description The unique alias for the instance */
-                    alias?: string;
+                    alias?: string | null;
                     /** @description The associated name */
                     name?: string;
                     /** @description The associated description */
@@ -25275,7 +25290,7 @@ export interface operations {
                         [key: string]: unknown;
                     };
                     /** @description The ID of the blueprint */
-                    blueprintId?: string;
+                    blueprintId?: string | null;
                     /** @description The ID of the bot this policy applies to. When omitted the policy is global and applies to every bot. */
                     botId?: string;
                     /**
@@ -25283,6 +25298,11 @@ export interface operations {
                      * @enum {string}
                      */
                     type: "retention" | "usage";
+                    /**
+                     * @description The lifecycle state of a resource - toggle it on/off without deleting it
+                     * @enum {string}
+                     */
+                    state?: "enabled" | "disabled";
                     /** @description The policy configuration as JSON */
                     config?: {
                         [key: string]: unknown;
@@ -26531,6 +26551,8 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": {
+                    /** @description The unique alias for the instance */
+                    alias?: string | null;
                     /** @description The associated name */
                     name?: string;
                     /** @description The associated description */
@@ -26540,17 +26562,22 @@ export interface operations {
                         [key: string]: unknown;
                     };
                     /** @description The ID of the blueprint */
-                    blueprintId?: string;
+                    blueprintId?: string | null;
                     /** @description The ID of the secret associated with the ability */
-                    secretId?: string;
+                    linkedSecretId?: string | null;
                     /** @description The ID of the file associated with the ability */
-                    fileId?: string;
+                    linkedFileId?: string | null;
                     /** @description The ID of the bot associated with the ability */
-                    botId?: string;
+                    linkedBotId?: string | null;
                     /** @description The ID of the space associated with the ability */
-                    spaceId?: string;
+                    linkedSpaceId?: string | null;
                     /** @description The text to update the ability with */
                     instruction?: string;
+                    /**
+                     * @description The lifecycle state of a resource - toggle it on/off without deleting it
+                     * @enum {string}
+                     */
+                    state?: "enabled" | "disabled";
                 };
             };
         };
@@ -26588,6 +26615,8 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": {
+                    /** @description The unique alias for the instance */
+                    alias?: string | null;
                     /** @description The associated name */
                     name?: string;
                     /** @description The associated description */
@@ -26597,17 +26626,22 @@ export interface operations {
                         [key: string]: unknown;
                     };
                     /** @description The ID of the blueprint */
-                    blueprintId?: string;
+                    blueprintId?: string | null;
                     /** @description The ID of the secret associated with the ability */
-                    secretId?: string;
+                    linkedSecretId?: string | null;
                     /** @description The ID of the file associated with the ability */
-                    fileId?: string;
+                    linkedFileId?: string | null;
                     /** @description The ID of the bot associated with the ability */
-                    botId?: string;
+                    linkedBotId?: string | null;
                     /** @description The ID of the space associated with the ability */
-                    spaceId?: string;
+                    linkedSpaceId?: string | null;
                     /** @description The instruction of the ability */
                     instruction?: string;
+                    /**
+                     * @description The lifecycle state of a resource - toggle it on/off without deleting it
+                     * @enum {string}
+                     */
+                    state?: "enabled" | "disabled";
                 };
             };
         };
@@ -26932,7 +26966,7 @@ export interface operations {
             content: {
                 "application/json": {
                     /** @description The unique alias for the instance */
-                    alias?: string;
+                    alias?: string | null;
                     /** @description The associated name */
                     name?: string;
                     /** @description The associated description */
@@ -26942,12 +26976,17 @@ export interface operations {
                         [key: string]: unknown;
                     };
                     /** @description The ID of the blueprint */
-                    blueprintId?: string;
+                    blueprintId?: string | null;
                     /**
                      * @description The skillset visibility
                      * @enum {string}
                      */
                     visibility?: "private" | "protected" | "public";
+                    /**
+                     * @description The lifecycle state of a resource - toggle it on/off without deleting it
+                     * @enum {string}
+                     */
+                    state?: "enabled" | "disabled";
                 };
             };
         };
@@ -26984,7 +27023,7 @@ export interface operations {
             content: {
                 "application/json": {
                     /** @description The unique alias for the instance */
-                    alias?: string;
+                    alias?: string | null;
                     /** @description The associated name */
                     name?: string;
                     /** @description The associated description */
@@ -26994,12 +27033,17 @@ export interface operations {
                         [key: string]: unknown;
                     };
                     /** @description The ID of the blueprint */
-                    blueprintId?: string;
+                    blueprintId?: string | null;
                     /**
                      * @description The skillset visibility
                      * @enum {string}
                      */
                     visibility?: "private" | "protected" | "public";
+                    /**
+                     * @description The lifecycle state of a resource - toggle it on/off without deleting it
+                     * @enum {string}
+                     */
+                    state?: "enabled" | "disabled";
                 };
             };
         };
@@ -27314,7 +27358,7 @@ export interface operations {
             content: {
                 "application/json": {
                     /** @description The unique alias for the instance */
-                    alias?: string;
+                    alias?: string | null;
                     /** @description The associated name */
                     name?: string;
                     /** @description The associated description */
@@ -27323,8 +27367,8 @@ export interface operations {
                     meta?: {
                         [key: string]: unknown;
                     };
-                    /** @description The host the site is served at (a <label>.chatbotkit.space subdomain) */
-                    domain?: string;
+                    /** @description The subdomain slug beneath the configured space apex */
+                    slug?: string;
                     /** @description Optional folder prefix inside the space to serve from */
                     prefix?: string;
                     /** @description Directory index filename */
@@ -27369,7 +27413,7 @@ export interface operations {
             content: {
                 "application/json": {
                     /** @description The unique alias for the instance */
-                    alias?: string;
+                    alias?: string | null;
                     /** @description The associated name */
                     name?: string;
                     /** @description The associated description */
@@ -27378,8 +27422,8 @@ export interface operations {
                     meta?: {
                         [key: string]: unknown;
                     };
-                    /** @description The host the site is served at (a <label>.chatbotkit.space subdomain) */
-                    domain: string;
+                    /** @description The subdomain slug beneath the configured space apex */
+                    slug: string;
                     /** @description Optional folder prefix inside the space to serve from */
                     prefix?: string;
                     /**
@@ -28427,6 +28471,8 @@ export interface operations {
                     meta?: {
                         [key: string]: unknown;
                     };
+                    /** @description The ID of the blueprint */
+                    blueprintId?: string | null;
                     /** @description The contact associated with the task */
                     contactId?: string;
                     /** @description The bot associated with the task */
@@ -28438,12 +28484,16 @@ export interface operations {
                      * @example America/New_York
                      */
                     timezone?: string | null;
+                    /** @description An optional epoch-millisecond timestamp after which the task is automatically deleted. Pass null to clear an existing expiry. */
+                    expiresAt?: number | null;
                     /** @description The session duration of the Widget integration */
                     sessionDuration?: number;
                     /** @description The maximum number of iterations per task execution */
                     maxIterations?: number;
                     /** @description The maximum time per task execution in milliseconds */
                     maxTime?: number;
+                    /** @description The maximum number of tool calls across the whole task run (0 or null for unbounded) */
+                    maxCalls?: number | null;
                 };
             };
         };
@@ -28487,6 +28537,8 @@ export interface operations {
                     meta?: {
                         [key: string]: unknown;
                     };
+                    /** @description The ID of the blueprint */
+                    blueprintId?: string | null;
                     /** @description The contact associated with the task */
                     contactId?: string;
                     /** @description The bot associated with the task */
@@ -28498,12 +28550,16 @@ export interface operations {
                      * @example America/New_York
                      */
                     timezone?: string | null;
+                    /** @description An optional epoch-millisecond timestamp after which the task is automatically deleted. Pass null or omit for no expiry. */
+                    expiresAt?: number | null;
                     /** @description The session duration of the Widget integration */
                     sessionDuration?: number;
                     /** @description The maximum number of iterations per task execution */
                     maxIterations?: number;
                     /** @description The maximum time per task execution in milliseconds */
                     maxTime?: number;
+                    /** @description The maximum number of tool calls across the whole task run (0 or null for unbounded) */
+                    maxCalls?: number | null;
                 };
             };
         };

--- a/packages/sdk/src/types/api/v1.json
+++ b/packages/sdk/src/types/api/v1.json
@@ -18152,7 +18152,8 @@
                 "properties": {
                   "alias": {
                     "type": "string",
-                    "description": "The unique alias for the instance"
+                    "description": "The unique alias for the instance",
+                    "nullable": true
                   },
                   "name": {
                     "type": "string",
@@ -18170,7 +18171,8 @@
                   },
                   "blueprintId": {
                     "type": "string",
-                    "description": "The ID of the blueprint"
+                    "description": "The ID of the blueprint",
+                    "nullable": true
                   },
                   "reranker": {
                     "description": "The reranker class for the dataset",
@@ -18284,7 +18286,8 @@
                 "properties": {
                   "alias": {
                     "type": "string",
-                    "description": "The unique alias for the instance"
+                    "description": "The unique alias for the instance",
+                    "nullable": true
                   },
                   "name": {
                     "type": "string",
@@ -18302,11 +18305,8 @@
                   },
                   "blueprintId": {
                     "type": "string",
-                    "description": "The ID of the blueprint"
-                  },
-                  "store": {
-                    "description": "The storage class for the dataset",
-                    "type": "string"
+                    "description": "The ID of the blueprint",
+                    "nullable": true
                   },
                   "reranker": {
                     "description": "The reranker class for the dataset",
@@ -24497,7 +24497,8 @@
                 "properties": {
                   "alias": {
                     "type": "string",
-                    "description": "The unique alias for the instance"
+                    "description": "The unique alias for the instance",
+                    "nullable": true
                   },
                   "name": {
                     "type": "string",
@@ -24515,15 +24516,23 @@
                   },
                   "blueprintId": {
                     "type": "string",
-                    "description": "The ID of the blueprint"
+                    "description": "The ID of the blueprint",
+                    "nullable": true
                   },
                   "botId": {
                     "type": "string",
-                    "description": "The ID of the bot this configuration is using"
+                    "description": "The ID of the bot this configuration is using",
+                    "nullable": true
                   },
                   "accessToken": {
                     "description": "The Instagram integration access token",
-                    "type": "string"
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "appSecret": {
+                    "description": "The Meta app secret used to validate webhook signatures",
+                    "type": "string",
+                    "nullable": true
                   },
                   "contactCollection": {
                     "description": "Whether to collect contacts",
@@ -24531,7 +24540,8 @@
                   },
                   "sessionDuration": {
                     "description": "The session duration (in milliseconds)",
-                    "type": "number"
+                    "type": "number",
+                    "nullable": true
                   },
                   "attachments": {
                     "description": "Whether the bot supports attachments",
@@ -24607,7 +24617,8 @@
                 "properties": {
                   "alias": {
                     "type": "string",
-                    "description": "The unique alias for the instance"
+                    "description": "The unique alias for the instance",
+                    "nullable": true
                   },
                   "name": {
                     "type": "string",
@@ -24625,15 +24636,23 @@
                   },
                   "blueprintId": {
                     "type": "string",
-                    "description": "The ID of the blueprint"
+                    "description": "The ID of the blueprint",
+                    "nullable": true
                   },
                   "botId": {
                     "type": "string",
-                    "description": "The ID of the bot this configuration is using"
+                    "description": "The ID of the bot this configuration is using",
+                    "nullable": true
                   },
                   "accessToken": {
                     "description": "The Instagram integration access token",
-                    "type": "string"
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "appSecret": {
+                    "description": "The Meta app secret used to validate webhook signatures",
+                    "type": "string",
+                    "nullable": true
                   },
                   "contactCollection": {
                     "description": "Whether to collect contacts",
@@ -24641,7 +24660,8 @@
                   },
                   "sessionDuration": {
                     "description": "The session duration (in milliseconds)",
-                    "type": "number"
+                    "type": "number",
+                    "nullable": true
                   },
                   "attachments": {
                     "description": "Whether the bot supports attachments",
@@ -25895,7 +25915,8 @@
                 "properties": {
                   "alias": {
                     "type": "string",
-                    "description": "The unique alias for the instance"
+                    "description": "The unique alias for the instance",
+                    "nullable": true
                   },
                   "name": {
                     "type": "string",
@@ -25913,15 +25934,23 @@
                   },
                   "blueprintId": {
                     "type": "string",
-                    "description": "The ID of the blueprint"
+                    "description": "The ID of the blueprint",
+                    "nullable": true
                   },
                   "botId": {
                     "type": "string",
-                    "description": "The ID of the bot this configuration is using"
+                    "description": "The ID of the bot this configuration is using",
+                    "nullable": true
                   },
                   "accessToken": {
                     "description": "The Messenger integration access token",
-                    "type": "string"
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "appSecret": {
+                    "description": "The Meta app secret used to validate webhook signatures",
+                    "type": "string",
+                    "nullable": true
                   },
                   "contactCollection": {
                     "description": "Whether to collect contacts",
@@ -25929,7 +25958,8 @@
                   },
                   "sessionDuration": {
                     "description": "The session duration (in milliseconds)",
-                    "type": "number"
+                    "type": "number",
+                    "nullable": true
                   },
                   "attachments": {
                     "description": "Whether the bot supports attachments",
@@ -26005,7 +26035,8 @@
                 "properties": {
                   "alias": {
                     "type": "string",
-                    "description": "The unique alias for the instance"
+                    "description": "The unique alias for the instance",
+                    "nullable": true
                   },
                   "name": {
                     "type": "string",
@@ -26023,15 +26054,23 @@
                   },
                   "blueprintId": {
                     "type": "string",
-                    "description": "The ID of the blueprint"
+                    "description": "The ID of the blueprint",
+                    "nullable": true
                   },
                   "botId": {
                     "type": "string",
-                    "description": "The ID of the bot this configuration is using"
+                    "description": "The ID of the bot this configuration is using",
+                    "nullable": true
                   },
                   "accessToken": {
                     "description": "The Messenger integration access token",
-                    "type": "string"
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "appSecret": {
+                    "description": "The Meta app secret used to validate webhook signatures",
+                    "type": "string",
+                    "nullable": true
                   },
                   "contactCollection": {
                     "description": "Whether to collect contacts",
@@ -26039,7 +26078,8 @@
                   },
                   "sessionDuration": {
                     "description": "The session duration (in milliseconds)",
-                    "type": "number"
+                    "type": "number",
+                    "nullable": true
                   },
                   "attachments": {
                     "description": "Whether the bot supports attachments",
@@ -33913,7 +33953,8 @@
                 "properties": {
                   "alias": {
                     "type": "string",
-                    "description": "The unique alias for the instance"
+                    "description": "The unique alias for the instance",
+                    "nullable": true
                   },
                   "name": {
                     "type": "string",
@@ -33931,19 +33972,28 @@
                   },
                   "blueprintId": {
                     "type": "string",
-                    "description": "The ID of the blueprint"
+                    "description": "The ID of the blueprint",
+                    "nullable": true
                   },
                   "botId": {
                     "type": "string",
-                    "description": "The ID of the bot this configuration is using"
+                    "description": "The ID of the bot this configuration is using",
+                    "nullable": true
                   },
                   "phoneNumberId": {
                     "description": "The WhatsApp integration phone number ID",
-                    "type": "string"
+                    "type": "string",
+                    "nullable": true
                   },
                   "accessToken": {
                     "description": "The WhatsApp integration access token",
-                    "type": "string"
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "appSecret": {
+                    "description": "The Meta app secret used to validate webhook signatures",
+                    "type": "string",
+                    "nullable": true
                   },
                   "contactCollection": {
                     "description": "Weather to collect contacts",
@@ -33951,7 +34001,8 @@
                   },
                   "sessionDuration": {
                     "description": "The session duration (in milliseconds)",
-                    "type": "number"
+                    "type": "number",
+                    "nullable": true
                   },
                   "attachments": {
                     "description": "Weather the bot supports attachments",
@@ -33959,7 +34010,8 @@
                   },
                   "allowFrom": {
                     "description": "Newline-or-comma-separated list of allowed senders. Use E.164 phone numbers with or without the leading `+`. Set to `*` to allow all. Leave empty to deny all.",
-                    "type": "string"
+                    "type": "string",
+                    "nullable": true
                   }
                 }
               }
@@ -34031,7 +34083,8 @@
                 "properties": {
                   "alias": {
                     "type": "string",
-                    "description": "The unique alias for the instance"
+                    "description": "The unique alias for the instance",
+                    "nullable": true
                   },
                   "name": {
                     "type": "string",
@@ -34049,19 +34102,28 @@
                   },
                   "blueprintId": {
                     "type": "string",
-                    "description": "The ID of the blueprint"
+                    "description": "The ID of the blueprint",
+                    "nullable": true
                   },
                   "botId": {
                     "type": "string",
-                    "description": "The ID of the bot this configuration is using"
+                    "description": "The ID of the bot this configuration is using",
+                    "nullable": true
                   },
                   "phoneNumberId": {
                     "description": "The WhatsApp integration phone number ID",
-                    "type": "string"
+                    "type": "string",
+                    "nullable": true
                   },
                   "accessToken": {
                     "description": "The WhatsApp integration access token",
-                    "type": "string"
+                    "type": "string",
+                    "nullable": true
+                  },
+                  "appSecret": {
+                    "description": "The Meta app secret used to validate webhook signatures",
+                    "type": "string",
+                    "nullable": true
                   },
                   "contactCollection": {
                     "description": "Weather to collect contacts",
@@ -34069,7 +34131,8 @@
                   },
                   "sessionDuration": {
                     "description": "The session duration (in milliseconds)",
-                    "type": "number"
+                    "type": "number",
+                    "nullable": true
                   },
                   "attachments": {
                     "description": "Weather the bot supports attachments",
@@ -34077,7 +34140,8 @@
                   },
                   "allowFrom": {
                     "description": "Newline-or-comma-separated list of allowed senders. Use E.164 phone numbers with or without the leading `+`. Set to `*` to allow all. Leave empty to deny all.",
-                    "type": "string"
+                    "type": "string",
+                    "nullable": true
                   }
                 }
               }
@@ -43798,7 +43862,8 @@
                 "properties": {
                   "alias": {
                     "type": "string",
-                    "description": "The unique alias for the instance"
+                    "description": "The unique alias for the instance",
+                    "nullable": true
                   },
                   "name": {
                     "type": "string",
@@ -43816,7 +43881,8 @@
                   },
                   "blueprintId": {
                     "type": "string",
-                    "description": "The ID of the blueprint"
+                    "description": "The ID of the blueprint",
+                    "nullable": true
                   },
                   "botId": {
                     "description": "The ID of the bot this policy applies to. When omitted the policy is global and applies to every bot.",
@@ -43830,6 +43896,15 @@
                       "usage"
                     ],
                     "$$ref": "#/components/schemas/PolicyType"
+                  },
+                  "state": {
+                    "type": "string",
+                    "description": "The lifecycle state of a resource - toggle it on/off without deleting it",
+                    "enum": [
+                      "enabled",
+                      "disabled"
+                    ],
+                    "$$ref": "#/components/schemas/ResourceState"
                   },
                   "config": {
                     "description": "The policy configuration as JSON",
@@ -43906,7 +43981,8 @@
                 "properties": {
                   "alias": {
                     "type": "string",
-                    "description": "The unique alias for the instance"
+                    "description": "The unique alias for the instance",
+                    "nullable": true
                   },
                   "name": {
                     "type": "string",
@@ -43924,7 +44000,8 @@
                   },
                   "blueprintId": {
                     "type": "string",
-                    "description": "The ID of the blueprint"
+                    "description": "The ID of the blueprint",
+                    "nullable": true
                   },
                   "botId": {
                     "description": "The ID of the bot this policy applies to. When omitted the policy is global and applies to every bot.",
@@ -43938,6 +44015,15 @@
                       "usage"
                     ],
                     "$$ref": "#/components/schemas/PolicyType"
+                  },
+                  "state": {
+                    "type": "string",
+                    "description": "The lifecycle state of a resource - toggle it on/off without deleting it",
+                    "enum": [
+                      "enabled",
+                      "disabled"
+                    ],
+                    "$$ref": "#/components/schemas/ResourceState"
                   },
                   "config": {
                     "description": "The policy configuration as JSON",
@@ -46727,9 +46813,14 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
                 "description": "Blueprint properties",
+                "type": "object",
                 "properties": {
+                  "alias": {
+                    "type": "string",
+                    "description": "The unique alias for the instance",
+                    "nullable": true
+                  },
                   "name": {
                     "type": "string",
                     "description": "The associated name"
@@ -46746,27 +46837,41 @@
                   },
                   "blueprintId": {
                     "type": "string",
-                    "description": "The ID of the blueprint"
+                    "description": "The ID of the blueprint",
+                    "nullable": true
                   },
-                  "secretId": {
+                  "linkedSecretId": {
                     "description": "The ID of the secret associated with the ability",
-                    "type": "string"
+                    "type": "string",
+                    "nullable": true
                   },
-                  "fileId": {
+                  "linkedFileId": {
                     "description": "The ID of the file associated with the ability",
-                    "type": "string"
+                    "type": "string",
+                    "nullable": true
                   },
-                  "botId": {
+                  "linkedBotId": {
                     "description": "The ID of the bot associated with the ability",
-                    "type": "string"
+                    "type": "string",
+                    "nullable": true
                   },
-                  "spaceId": {
+                  "linkedSpaceId": {
                     "description": "The ID of the space associated with the ability",
-                    "type": "string"
+                    "type": "string",
+                    "nullable": true
                   },
                   "instruction": {
                     "description": "The text to update the ability with",
                     "type": "string"
+                  },
+                  "state": {
+                    "type": "string",
+                    "description": "The lifecycle state of a resource - toggle it on/off without deleting it",
+                    "enum": [
+                      "enabled",
+                      "disabled"
+                    ],
+                    "$$ref": "#/components/schemas/ResourceState"
                   }
                 }
               }
@@ -46843,9 +46948,14 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
                 "description": "Blueprint properties",
+                "type": "object",
                 "properties": {
+                  "alias": {
+                    "type": "string",
+                    "description": "The unique alias for the instance",
+                    "nullable": true
+                  },
                   "name": {
                     "type": "string",
                     "description": "The associated name"
@@ -46862,27 +46972,41 @@
                   },
                   "blueprintId": {
                     "type": "string",
-                    "description": "The ID of the blueprint"
+                    "description": "The ID of the blueprint",
+                    "nullable": true
                   },
-                  "secretId": {
+                  "linkedSecretId": {
                     "description": "The ID of the secret associated with the ability",
-                    "type": "string"
+                    "type": "string",
+                    "nullable": true
                   },
-                  "fileId": {
+                  "linkedFileId": {
                     "description": "The ID of the file associated with the ability",
-                    "type": "string"
+                    "type": "string",
+                    "nullable": true
                   },
-                  "botId": {
+                  "linkedBotId": {
                     "description": "The ID of the bot associated with the ability",
-                    "type": "string"
+                    "type": "string",
+                    "nullable": true
                   },
-                  "spaceId": {
+                  "linkedSpaceId": {
                     "description": "The ID of the space associated with the ability",
-                    "type": "string"
+                    "type": "string",
+                    "nullable": true
                   },
                   "instruction": {
                     "description": "The instruction of the ability",
                     "type": "string"
+                  },
+                  "state": {
+                    "type": "string",
+                    "description": "The lifecycle state of a resource - toggle it on/off without deleting it",
+                    "enum": [
+                      "enabled",
+                      "disabled"
+                    ],
+                    "$$ref": "#/components/schemas/ResourceState"
                   }
                 }
               }
@@ -47651,7 +47775,8 @@
                 "properties": {
                   "alias": {
                     "type": "string",
-                    "description": "The unique alias for the instance"
+                    "description": "The unique alias for the instance",
+                    "nullable": true
                   },
                   "name": {
                     "type": "string",
@@ -47669,7 +47794,8 @@
                   },
                   "blueprintId": {
                     "type": "string",
-                    "description": "The ID of the blueprint"
+                    "description": "The ID of the blueprint",
+                    "nullable": true
                   },
                   "visibility": {
                     "type": "string",
@@ -47680,6 +47806,15 @@
                       "public"
                     ],
                     "$$ref": "#/components/schemas/SkillsetVisibility"
+                  },
+                  "state": {
+                    "type": "string",
+                    "description": "The lifecycle state of a resource - toggle it on/off without deleting it",
+                    "enum": [
+                      "enabled",
+                      "disabled"
+                    ],
+                    "$$ref": "#/components/schemas/ResourceState"
                   }
                 }
               }
@@ -47751,7 +47886,8 @@
                 "properties": {
                   "alias": {
                     "type": "string",
-                    "description": "The unique alias for the instance"
+                    "description": "The unique alias for the instance",
+                    "nullable": true
                   },
                   "name": {
                     "type": "string",
@@ -47769,7 +47905,8 @@
                   },
                   "blueprintId": {
                     "type": "string",
-                    "description": "The ID of the blueprint"
+                    "description": "The ID of the blueprint",
+                    "nullable": true
                   },
                   "visibility": {
                     "type": "string",
@@ -47780,6 +47917,15 @@
                       "public"
                     ],
                     "$$ref": "#/components/schemas/SkillsetVisibility"
+                  },
+                  "state": {
+                    "type": "string",
+                    "description": "The lifecycle state of a resource - toggle it on/off without deleting it",
+                    "enum": [
+                      "enabled",
+                      "disabled"
+                    ],
+                    "$$ref": "#/components/schemas/ResourceState"
                   }
                 }
               }
@@ -48493,7 +48639,8 @@
                 "properties": {
                   "alias": {
                     "type": "string",
-                    "description": "The unique alias for the instance"
+                    "description": "The unique alias for the instance",
+                    "nullable": true
                   },
                   "name": {
                     "type": "string",
@@ -48509,8 +48656,8 @@
                     "additionalProperties": true,
                     "$$ref": "#/components/schemas/Meta"
                   },
-                  "domain": {
-                    "description": "The host the site is served at (a <label>.chatbotkit.space subdomain)",
+                  "slug": {
+                    "description": "The subdomain slug beneath the configured space apex",
                     "type": "string"
                   },
                   "prefix": {
@@ -48605,7 +48752,8 @@
                 "properties": {
                   "alias": {
                     "type": "string",
-                    "description": "The unique alias for the instance"
+                    "description": "The unique alias for the instance",
+                    "nullable": true
                   },
                   "name": {
                     "type": "string",
@@ -48621,8 +48769,8 @@
                     "additionalProperties": true,
                     "$$ref": "#/components/schemas/Meta"
                   },
-                  "domain": {
-                    "description": "The host the site is served at (a <label>.chatbotkit.space subdomain)",
+                  "slug": {
+                    "description": "The subdomain slug beneath the configured space apex",
                     "type": "string"
                   },
                   "prefix": {
@@ -48641,7 +48789,7 @@
                   }
                 },
                 "required": [
-                  "domain"
+                  "slug"
                 ]
               }
             }
@@ -51035,7 +51183,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "description": "Instance crud properties",
+                "description": "Blueprint properties",
                 "properties": {
                   "name": {
                     "type": "string",
@@ -51050,6 +51198,11 @@
                     "description": "Meta data information",
                     "additionalProperties": true,
                     "$$ref": "#/components/schemas/Meta"
+                  },
+                  "blueprintId": {
+                    "type": "string",
+                    "description": "The ID of the blueprint",
+                    "nullable": true
                   },
                   "contactId": {
                     "type": "string",
@@ -51069,6 +51222,11 @@
                     "description": "An optional IANA timezone identifier used when evaluating the task schedule.",
                     "example": "America/New_York"
                   },
+                  "expiresAt": {
+                    "type": "number",
+                    "nullable": true,
+                    "description": "An optional epoch-millisecond timestamp after which the task is automatically deleted. Pass null to clear an existing expiry."
+                  },
                   "sessionDuration": {
                     "description": "The session duration of the Widget integration",
                     "type": "number"
@@ -51080,6 +51238,11 @@
                   "maxTime": {
                     "description": "The maximum time per task execution in milliseconds",
                     "type": "number"
+                  },
+                  "maxCalls": {
+                    "description": "The maximum number of tool calls across the whole task run (0 or null for unbounded)",
+                    "type": "number",
+                    "nullable": true
                   }
                 }
               }
@@ -51148,7 +51311,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "description": "Instance crud properties",
+                "description": "Blueprint properties",
                 "properties": {
                   "name": {
                     "type": "string",
@@ -51163,6 +51326,11 @@
                     "description": "Meta data information",
                     "additionalProperties": true,
                     "$$ref": "#/components/schemas/Meta"
+                  },
+                  "blueprintId": {
+                    "type": "string",
+                    "description": "The ID of the blueprint",
+                    "nullable": true
                   },
                   "contactId": {
                     "type": "string",
@@ -51182,6 +51350,11 @@
                     "description": "An optional IANA timezone identifier used when evaluating the task schedule.",
                     "example": "America/New_York"
                   },
+                  "expiresAt": {
+                    "type": "number",
+                    "nullable": true,
+                    "description": "An optional epoch-millisecond timestamp after which the task is automatically deleted. Pass null or omit for no expiry."
+                  },
                   "sessionDuration": {
                     "description": "The session duration of the Widget integration",
                     "type": "number"
@@ -51193,6 +51366,11 @@
                   "maxTime": {
                     "description": "The maximum time per task execution in milliseconds",
                     "type": "number"
+                  },
+                  "maxCalls": {
+                    "description": "The maximum number of tool calls across the whole task run (0 or null for unbounded)",
+                    "type": "number",
+                    "nullable": true
                   }
                 }
               }


### PR DESCRIPTION
Refreshes the affected generated API operations and ability catalogue types without syncing unrelated monorepo drift.\n\nValidated by:\n- SDK check and build\n- packing the resulting @chatbotkit/sdk tarball\n- installing it into a clean public-platform export\n- running the exact application tsc command from the failed CI job (passes in 12.84s)